### PR TITLE
Add Azure Python runner node

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# custom-python-n8n-node
+# Custom Python n8n Node
+
+This repository contains a simple n8n node named `AzurePythonRunner` which fetches a public Python file and sends its contents to an Azure Container App Session Pools endpoint for execution.
+
+## Node
+
+The node can be found in `nodes/AzurePythonRunner.node.ts` and exposes two parameters:
+
+- **Python File URL** – public URL of the Python script to execute.
+- **Azure Session Pools Endpoint** – HTTP endpoint of your Azure Container App Session Pools instance.
+
+The node retrieves the file from the supplied URL, then posts the code to the specified endpoint. The response from the endpoint is returned as the node output.
+
+## Usage
+
+1. Build the node with the rest of your n8n extensions.
+2. Configure the two parameters when using the node in your workflow.
+
+This repository contains only the source TypeScript file. You may need to transpile it to JavaScript before loading it into n8n depending on your setup.

--- a/nodes/AzurePythonRunner.node.ts
+++ b/nodes/AzurePythonRunner.node.ts
@@ -1,0 +1,59 @@
+import axios from 'axios';
+import { IExecuteFunctions } from 'n8n-core';
+import { INodeType, INodeTypeDescription, IDataObject } from 'n8n-workflow';
+
+export class AzurePythonRunner implements INodeType {
+    description: INodeTypeDescription = {
+        displayName: 'Azure Python Runner',
+        name: 'azurePythonRunner',
+        group: ['transform'],
+        version: 1,
+        description: 'Execute a public Python file on Azure Container App Session Pools',
+        defaults: {
+            name: 'Azure Python Runner',
+            color: '#00AAFF',
+        },
+        inputs: ['main'],
+        outputs: ['main'],
+        properties: [
+            {
+                displayName: 'Python File URL',
+                name: 'pythonFileUrl',
+                type: 'string',
+                default: '',
+                placeholder: 'https://example.com/script.py',
+                description: 'Public URL to the Python script',
+            },
+            {
+                displayName: 'Azure Session Pools Endpoint',
+                name: 'endpoint',
+                type: 'string',
+                default: '',
+                placeholder: 'https://your-app.azurecontainerapps.io/run',
+                description: 'Endpoint that runs the Python code',
+            },
+        ],
+    };
+
+    async execute(this: IExecuteFunctions) {
+        const items = this.getInputData();
+        const returnData = [] as IDataObject[];
+
+        for (let i = 0; i < items.length; i++) {
+            const pythonFileUrl = this.getNodeParameter('pythonFileUrl', i) as string;
+            const endpoint = this.getNodeParameter('endpoint', i) as string;
+
+            const fileResponse = await axios.get<string>(pythonFileUrl);
+            const code = fileResponse.data;
+
+            const response = await axios.post(endpoint, { code });
+            returnData.push({ json: response.data });
+        }
+
+        return [
+            {
+                json: returnData,
+            },
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- document repo for custom n8n node
- add `AzurePythonRunner` node for running a Python script via Azure Container App Session Pools

## Testing
- `git status --short`