### PR TITLE
Fix node typings for n8n v1

### DIFF
--- a/nodes/AzurePythonRunner.node.ts
+++ b/nodes/AzurePythonRunner.node.ts
@@ -1,6 +1,11 @@
 import axios from 'axios';
-import { IExecuteFunctions } from 'n8n-core';
-import { INodeType, INodeTypeDescription, IDataObject } from 'n8n-workflow';
+import {
+    IExecuteFunctions,
+    INodeType,
+    INodeTypeDescription,
+    IDataObject,
+    INodeExecutionData,
+} from 'n8n-workflow';
 
 export class AzurePythonRunner implements INodeType {
     description: INodeTypeDescription = {
@@ -37,7 +42,7 @@ export class AzurePythonRunner implements INodeType {
 
     async execute(this: IExecuteFunctions) {
         const items = this.getInputData();
-        const returnData = [] as IDataObject[];
+        const returnData = [] as INodeExecutionData[];
 
         for (let i = 0; i < items.length; i++) {
             const pythonFileUrl = this.getNodeParameter('pythonFileUrl', i) as string;
@@ -50,10 +55,6 @@ export class AzurePythonRunner implements INodeType {
             returnData.push({ json: response.data });
         }
 
-        return [
-            {
-                json: returnData,
-            },
-        ];
+        return [returnData];
     }
 }


### PR DESCRIPTION
## Summary
- fix imports for `IExecuteFunctions` to use `n8n-workflow`
- return proper `INodeExecutionData` array from execute

## Testing
- `npx tsc` *(fails: Cannot find module 'axios' or 'n8n-workflow' because dependencies are not installed)*